### PR TITLE
Update setUpSourceDisplayFacade.js

### DIFF
--- a/src/core/sources/setUpSourceDisplayFacade.js
+++ b/src/core/sources/setUpSourceDisplayFacade.js
@@ -7,7 +7,9 @@ export function setUpSourceDisplayFacade(
 ) {
     self.displayStageSourcesIfNotYet = () => {
         for (let i in stageIndexes) {
-            updateSourceInnerCollection[stageIndexes[i]]();
+            if (updateSourceInnerCollection[stageIndexes[i]]) {
+                updateSourceInnerCollection[stageIndexes[i]]();
+            }
         }
     };
 }


### PR DESCRIPTION
fix calling an 'undefined' function when a toggler is initialized twice

Affected versions are 1.4.3 and 1.4.4

Steps to reproduce:
- run `yarn watch`
- click "Toggle Lightbox" /the right button/
- close the lightbox
- try to open it again