### PR TITLE
Disabled double-tap to zoom on all viewports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fslightbox-react",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "React version of Fullscreen Lightbox. Modern and easy plugin for displaying images and videos in clean overlaying box. Display single source or create beautiful gallery with powerful lightbox.",
   "main": "index.js",
   "scripts": {

--- a/src/scss/components/slide-buttons/SlideButtons.scss
+++ b/src/scss/components/slide-buttons/SlideButtons.scss
@@ -7,6 +7,7 @@
   cursor: pointer;
   z-index: 3;
   transform: translateY(-50%);
+  touch-action: manipulation;
 
   @media (min-width: 476px) {
     padding: 22px 22px 22px 6px;


### PR DESCRIPTION
Added "touch-action: manipulation;" to the prev/next buttons, so the double-tap on them won't cause an image to zoom.  